### PR TITLE
Only switch theme in current Workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Theme by language",
     "description": "Change the color theme based on the current file language",
     "version": "1.1.1",
-    "publisher": "jsaulou",
+    "publisher": "Voklen",
     "icon": "images/icon.png",
     "galleryBanner": {
         "color": "#ff9356",
@@ -11,7 +11,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/jsaulou/vscode-theme-by-language.git"
+        "url": "https://github.com/Voklen/vscode-theme-by-language.git"
     },
     "engines": {
         "vscode": "^1.23.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Theme by language",
     "description": "Change the color theme based on the current file language",
     "version": "1.1.1",
-    "publisher": "Voklen",
+    "publisher": "jsaulou",
     "icon": "images/icon.png",
     "galleryBanner": {
         "color": "#ff9356",
@@ -11,7 +11,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Voklen/vscode-theme-by-language.git"
+        "url": "https://github.com/jsaulou/vscode-theme-by-language.git"
     },
     "engines": {
         "vscode": "^1.23.0"

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -65,7 +65,7 @@ export function applyLanguageTheme(language: string) {
 
 export function applyTheme(theme: string) {
     if (theme !== getWorkbenchTheme()) {
-        return vscode.workspace.getConfiguration().update(WORKBENCH_COLOR_THEME, theme, true);
+        return vscode.workspace.getConfiguration().update(WORKBENCH_COLOR_THEME, theme, false);
     }
 }
 


### PR DESCRIPTION
fixes #13

The `ConfigurationTarget` boolean governs whether "theme changes" are local or global

If `ConfigurationTarget` is `true`, `ConfigurationTarget.Global` is used.
If `ConfigurationTarget` is `false`, `ConfigurationTarget.Workspace` is used.

So I just changed the variable from `true` to `false`

Before:
![Before](https://user-images.githubusercontent.com/56766748/86384905-51f77480-bc87-11ea-90b3-7b2a136e67d4.gif)

After:
![After](https://user-images.githubusercontent.com/56766748/86385339-04c7d280-bc88-11ea-8314-55b7b8b96ca3.gif)
